### PR TITLE
Fix Terraform SSH key path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ This project uses Terraform to provision a basic infrastructure on AWS, includin
 - `/` → "Hola desde Flask en EC2!"
 - `/inventario` → Returns a JSON list of items.
 
-## 🔐 Notes
-
-- The EC2 instance uses `user_data` to automatically install dependencies and launch the Flask app.
+- The EC2 instance uses `user_data` to install dependencies and create a systemd service so the Flask app starts automatically.
 - Make sure your `.pem` file (key pair) is secured and added to your SSH agent.
 - Provide the path to your public key using the `public_key_path` variable when
   running Terraform.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ This project uses Terraform to provision a basic infrastructure on AWS, includin
    terraform plan
    ```
 
-4. Apply the infrastructure:
+4. Apply the infrastructure (remember to pass the path to your public SSH key):
    ```bash
-   terraform apply
+   terraform apply -var="public_key_path=~/.ssh/flask-key.pub"
    ```
 
 5. Once the infrastructure is deployed, copy the EC2 public IP and open it in your browser:
@@ -62,6 +62,8 @@ This project uses Terraform to provision a basic infrastructure on AWS, includin
 
 - The EC2 instance uses `user_data` to automatically install dependencies and launch the Flask app.
 - Make sure your `.pem` file (key pair) is secured and added to your SSH agent.
+- Provide the path to your public key using the `public_key_path` variable when
+  running Terraform.
 
 ## 🧹 To Destroy
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -157,7 +157,9 @@ resource "aws_security_group" "ec2_sg" {
 
 resource "aws_key_pair" "flask_key" {
   key_name   = "flask-key"
-  public_key = file("~/.ssh/flask-key.pub") # Ruta absoluta
+  # Terraform no expande la tilde (~), por lo que usamos una variable
+  # para especificar la ruta del archivo de clave pública.
+  public_key = file(var.public_key_path)
 }
 
 resource "aws_instance" "flask_server" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -25,3 +25,8 @@ variable "db_password" {
   type        = string
   sensitive   = true
 }
+
+variable "public_key_path" {
+  description = "Ruta al archivo de clave pública SSH"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- allow custom path for SSH key via new `public_key_path` variable
- use new variable in EC2 key pair resource
- document how to pass `public_key_path`

## Testing
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687598c938188329a2261b723b958a15