### PR TITLE
Fix deploy workflow for env file

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -22,10 +22,12 @@ jobs:
       - name: Deploy app via SSH
         run: |
           ssh -o StrictHostKeyChecking=no -i flask-key.pem ec2-user@${{ secrets.EC2_HOST }} << 'EOF'
-            cd /home/ec2-user/fullstack-app-aws-terraform/app
+            set -e
+            cd /home/ec2-user/fullstack-app-aws-terraform
             git pull
+            cd app
             docker build -t flask-app .
             docker stop flask-container || true
             docker rm flask-container || true
-            docker run -d -p 5000:5000 --name flask-container flask-app
+            docker run -d --env-file .env -p 5000:5000 --name flask-container flask-app
           EOF


### PR DESCRIPTION
## Summary
- ensure deploy script uses repo root and .env file when rebuilding container

## Testing
- `apt-get update` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_6876d9a7a4f48329aacaf21724168b78